### PR TITLE
Refactor integration tests & fix match insert bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 /.cargo
 /coverage
+/.vscode

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -96,7 +96,7 @@ pub async fn register_player(
     match_id: Path<i64>,
     mut payload: Json<PlayerMatchRegistrationRequest>,
     player_registration_store: Data<PlayerRegistrationStore>,
-    match_store: Data<MatchStore>
+    match_store: Data<MatchStore>,
 ) -> Result<impl Responder, ServerError> {
     let match_data = match_store.get_match(*match_id).await?;
 
@@ -104,10 +104,12 @@ pub async fn register_player(
         return Err(ServerError::InvalidPlayerRegistration);
     }
 
-    let previous_registration = player_registration_store.get_player_registration(payload.player_id, *match_id).await?; 
+    let previous_registration = player_registration_store
+        .get_player_registration(payload.player_id, *match_id)
+        .await?;
     if previous_registration.is_some() {
         return Err(ServerError::PlayerAlreadyReigstered);
-    } 
+    }
 
     let registered_by = std::mem::take(&mut payload.registered_by);
     let match_registration = player_registration_store

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -75,8 +75,9 @@ pub async fn insert_match(
     db: Data<MatchStore>,
 ) -> Result<impl Responder, ServerError> {
     if match_data.start_time < Local::now().naive_local() {
-        println!("invalid");
         Err(ServerError::InvalidStartTime)
+    } else if match_data.player_one == match_data.player_two {
+        Err(ServerError::InvalidRooster)
     } else {
         let id = db.insert_match(match_data.into_inner()).await?;
         Ok(HttpResponse::Ok().body(id.to_string()))

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -89,15 +89,28 @@ pub struct PlayerMatchRegistrationRequest {
     pub player_id: i64,
     pub registered_by: String,
 }
+
 // TODO: This should probably take a form instead
 #[post("/matches/{match_id}/register/player")]
 pub async fn register_player(
     match_id: Path<i64>,
     mut payload: Json<PlayerMatchRegistrationRequest>,
-    store: Data<PlayerRegistrationStore>,
+    player_registration_store: Data<PlayerRegistrationStore>,
+    match_store: Data<MatchStore>
 ) -> Result<impl Responder, ServerError> {
+    let match_data = match_store.get_match(*match_id).await?;
+
+    if match_data.player_one != payload.player_id && match_data.player_two != payload.player_id {
+        return Err(ServerError::InvalidPlayerRegistration);
+    }
+
+    let previous_registration = player_registration_store.get_player_registration(payload.player_id, *match_id).await?; 
+    if previous_registration.is_some() {
+        return Err(ServerError::PlayerAlreadyReigstered);
+    } 
+
     let registered_by = std::mem::take(&mut payload.registered_by);
-    let match_registration = store
+    let match_registration = player_registration_store
         .insert_player_registration(payload.player_id, *match_id, registered_by)
         .await?;
     Ok(HttpResponse::Ok().json(match_registration))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@ pub enum ServerError {
     InvalidDate,
     #[error("Invalid start time")]
     InvalidStartTime,
+    #[error("Invalid rooster, two different players are needed")]
+    InvalidRooster,
     #[error("Internal Database error")]
     InternalDataBaseError(#[from] sqlx::Error),
 }
@@ -32,9 +34,9 @@ pub enum ServerError {
 impl ResponseError for ServerError {
     fn status_code(&self) -> http::StatusCode {
         match &self {
-            ServerError::InvalidDate | ServerError::InvalidStartTime => {
-                http::StatusCode::BAD_REQUEST
-            }
+            ServerError::InvalidDate
+            | ServerError::InvalidRooster
+            | ServerError::InvalidStartTime => http::StatusCode::BAD_REQUEST,
             // Todo: log the actual error
             ServerError::InternalDataBaseError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@ pub enum ServerError {
     InvalidStartTime,
     #[error("Invalid rooster, two different players are needed")]
     InvalidRooster,
+    #[error("Invalid player registration")]
+    InvalidPlayerRegistration,
+    #[error("Player already registered to match")]
+    PlayerAlreadyReigstered,
     #[error("Internal Database error")]
     InternalDataBaseError(#[from] sqlx::Error),
 }
@@ -36,7 +40,9 @@ impl ResponseError for ServerError {
         match &self {
             ServerError::InvalidDate
             | ServerError::InvalidRooster
-            | ServerError::InvalidStartTime => http::StatusCode::BAD_REQUEST,
+            | ServerError::InvalidStartTime
+            | ServerError::InvalidPlayerRegistration
+            | ServerError::PlayerAlreadyReigstered => http::StatusCode::BAD_REQUEST,
             // Todo: log the actual error
             ServerError::InternalDataBaseError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
         }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,126 @@
+use std::net::TcpListener;
+
+use reqwest::{Client, Response};
+use sqlx::{Connection, Executor};
+use sqlx::{PgConnection, PgPool};
+use tokio::runtime::Runtime;
+use tournament_tracker_backend::{
+    configuration::{get_configuration, DatabaseSettings},
+    endpoints::PlayerMatchRegistrationRequest,
+    stores::match_store::Match,
+    stores::{player_store::Player, tournament_store::Tournament},
+};
+use uuid::Uuid;
+
+pub struct TournamentTrackerClient {
+    pub client: Client,
+    pub server_addr: String,
+}
+
+impl TournamentTrackerClient {
+    pub async fn insert_tournament(&self, tournament: &Tournament) -> Response {
+        self.client
+            .post(&format!("{}/tournaments", &self.server_addr))
+            .json(&tournament)
+            .send()
+            .await
+            .expect("Request failed")
+    }
+
+    pub async fn get_tournaments(&self) -> Response {
+        self.client
+            .get(&format!("{}/tournaments", &self.server_addr))
+            .send()
+            .await
+            .expect("Request failed")
+    }
+
+    pub async fn insert_player(&self, player: &Player) -> Response {
+        self.client
+            .post(&format!("{}/players", &self.server_addr))
+            .json(&player)
+            .send()
+            .await
+            .expect("Request failed")
+    }
+
+    pub async fn get_player(&self, player_id: i64) -> Response {
+        self.client
+            .get(&format!("{}/players/{}", &self.server_addr, player_id))
+            .send()
+            .await
+            .expect("Request failed")
+    }
+
+    pub async fn insert_match(&self, match_data: &Match) -> Response {
+        self.client
+            .post(&format!("{}/matches", &self.server_addr))
+            .json(&match_data)
+            .send()
+            .await
+            .expect("Request failed")
+    }
+
+    pub async fn register_player(
+        &self,
+        match_id: i64,
+        player_registration_req: &PlayerMatchRegistrationRequest,
+    ) -> Response {
+        self.client
+            .post(&format!(
+                "{}/matches/{}/register/player",
+                &self.server_addr, match_id
+            ))
+            .json(&player_registration_req)
+            .send()
+            .await
+            .expect("Request failed")
+    }
+}
+
+pub async fn spawn_server() -> TournamentTrackerClient {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
+    let port = listener.local_addr().unwrap().port();
+
+    let mut configuration = get_configuration().expect("Failed to read configuration.");
+
+    // Randomise database name:
+    configuration.database.database_name = Uuid::new_v4().to_string();
+
+    let connection_pool = configure_database(&configuration.database).await;
+
+    let server = tournament_tracker_backend::run(listener, connection_pool)
+        .expect("Failed to create server");
+    let rt = Runtime::new().expect("Failed to start tokio runtime");
+    // tokio, unlike smol detaches when task handle is droppped
+    rt.block_on(async {
+        let _ = tokio::spawn(server);
+    });
+
+    TournamentTrackerClient {
+        server_addr: format!("http://127.0.0.1:{}", port),
+        client: reqwest::Client::new(),
+    }
+}
+
+pub async fn configure_database(config: &DatabaseSettings) -> PgPool {
+    // Create database
+    let mut connection = PgConnection::connect(&config.connection_string_without_db())
+        .await
+        .expect("Failed to connect to Postgres");
+    connection
+        .execute(&*format!(r#"CREATE DATABASE "{}";"#, config.database_name))
+        .await
+        .expect("Failed to create database.");
+
+    // Migrate database
+    let connection_pool = PgPool::connect(&config.connection_string())
+        .await
+        .expect("Failed to connect to Postgres.");
+    sqlx::migrate!("./migrations")
+        .run(&connection_pool)
+        .await
+        .expect("Failed to migrate the database");
+
+    connection_pool
+}

--- a/tests/endpoint_tests.rs
+++ b/tests/endpoint_tests.rs
@@ -1,73 +1,16 @@
-use std::net::TcpListener;
-
-use chrono::{Duration, Local};
 use reqwest::StatusCode;
-use sqlx::{Connection, Executor};
-use sqlx::{PgConnection, PgPool};
-use tokio::runtime::Runtime;
-use tournament_tracker_backend::{
-    configuration::{get_configuration, DatabaseSettings},
-    endpoints::PlayerMatchRegistrationRequest,
-    stores::match_store::Match,
-    stores::{
-        player_registration_store::PlayerMatchRegistration, player_store::Player,
-        tournament_store::Tournament,
-    },
-};
-use uuid::Uuid;
+use tournament_tracker_backend::stores::player_store::Player;
 
-async fn spawn_server() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind address");
-    let port = listener.local_addr().unwrap().port();
-
-    let mut configuration = get_configuration().expect("Failed to read configuration.");
-
-    // Randomise database name:
-    configuration.database.database_name = Uuid::new_v4().to_string();
-
-    let connection_pool = configure_database(&configuration.database).await;
-
-    let server = tournament_tracker_backend::run(listener, connection_pool)
-        .expect("Failed to create server");
-    let rt = Runtime::new().expect("Failed to start tokio runtime");
-    // tokio, unlike smol detaches when task handle is droppped
-    rt.block_on(async {
-        let _ = tokio::spawn(server);
-    });
-    // return the server address
-    format!("http://127.0.0.1:{}", port)
-}
-
-pub async fn configure_database(config: &DatabaseSettings) -> PgPool {
-    // Create database
-    let mut connection = PgConnection::connect(&config.connection_string_without_db())
-        .await
-        .expect("Failed to connect to Postgres");
-    connection
-        .execute(&*format!(r#"CREATE DATABASE "{}";"#, config.database_name))
-        .await
-        .expect("Failed to create database.");
-
-    // Migrate database
-    let connection_pool = PgPool::connect(&config.connection_string())
-        .await
-        .expect("Failed to connect to Postgres.");
-    sqlx::migrate!("./migrations")
-        .run(&connection_pool)
-        .await
-        .expect("Failed to migrate the database");
-
-    connection_pool
-}
+use common::spawn_server;
+mod common;
 
 #[actix_rt::test]
 async fn health_check_test() {
-    let server_addr = spawn_server().await;
+    let tt_client = spawn_server().await;
 
-    let client = reqwest::Client::new();
-
-    let response = client
-        .get(&format!("{}/health_check", &server_addr))
+    let response = tt_client
+        .client
+        .get(&format!("{}/health_check", &tt_client.server_addr))
         .send()
         .await
         .expect("Request failed");
@@ -77,100 +20,19 @@ async fn health_check_test() {
 }
 
 #[actix_rt::test]
-async fn insert_tournament_test() {
-    let server_addr = spawn_server().await;
-
-    let client = reqwest::Client::new();
-    let start_date = Local::today().naive_local();
-
-    let tournament = Tournament {
-        id: 0, // doesn't matter
-        name: "Södertälje open".into(),
-        start_date,
-        end_date: start_date + Duration::days(1),
-    };
-
-    let response = client
-        .post(&format!("{}/tournaments", &server_addr))
-        .json(&tournament)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-}
-
-#[actix_rt::test]
-async fn get_tournament_test() {
-    let server_addr = spawn_server().await;
-
-    let client = reqwest::Client::new();
-    let start_date = Local::today().naive_local();
-
-    let tournament = Tournament {
-        id: 0, // doesn't matter
-        name: "Södertälje open".into(),
-        start_date,
-        end_date: start_date + Duration::days(1),
-    };
-
-    let response = client
-        .post(&format!("{}/tournaments", &server_addr))
-        .json(&tournament)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-
-    // get tournament:
-
-    let response = client
-        .get(&format!("{}/tournaments", &server_addr))
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-    let tournament_list = response
-        .json::<Vec<Tournament>>()
-        .await
-        .expect("Response body");
-    assert_eq!(tournament_list.len(), 1);
-
-    let tournament = Tournament {
-        id: tournament_list[0].id,
-        ..tournament
-    };
-
-    assert_eq!(tournament_list[0], tournament);
-}
-
-#[actix_rt::test]
 async fn insert_and_get_player_test() {
-    let server_addr = spawn_server().await;
-
-    let client = reqwest::Client::new();
+    let client = spawn_server().await;
 
     let player = Player {
         id: 3,
         name: "Göte svensson".into(),
     };
 
-    let response = client
-        .post(&format!("{}/players", &server_addr))
-        .json(&player)
-        .send()
-        .await
-        .expect("Request failed");
+    let response = client.insert_player(&player).await;
 
     assert!(response.status().is_success());
 
-    let response = client
-        .get(&format!("{}/players/3", &server_addr))
-        .send()
-        .await
-        .expect("Request failed");
+    let response = client.get_player(player.id).await;
 
     assert!(response.status().is_success());
     assert_eq!(
@@ -181,138 +43,7 @@ async fn insert_and_get_player_test() {
 
 #[actix_rt::test]
 async fn should_404_on_missing_player() {
-    let server_addr = spawn_server().await;
-
-    let client = reqwest::Client::new();
-
-    let response = client
-        .get(&format!("{}/players/3", &server_addr))
-        .send()
-        .await
-        .expect("Request failed");
-
+    let client = spawn_server().await;
+    let response = client.get_player(3).await;
     assert_eq!(response.status(), StatusCode::from_u16(404).unwrap());
 }
-
-#[actix_rt::test]
-async fn should_fail_invalid_player_registration() {
-    let server_addr = spawn_server().await;
-
-    let client = reqwest::Client::new();
-
-    let player_registration_request = PlayerMatchRegistrationRequest {
-        player_id: 0,
-        registered_by: "Svante".to_string(),
-    };
-
-    let response = client
-        .post(&format!("{}/matches/0/register/player", &server_addr))
-        .json(&player_registration_request)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert_eq!(response.status(), StatusCode::from_u16(500).unwrap());
-}
-
-#[actix_rt::test]
-async fn should_register_player() {
-    let server_addr = spawn_server().await;
-
-    let client = reqwest::Client::new();
-
-    let start_date = Local::today().naive_local();
-
-    let tournament = Tournament {
-        id: 0, // doesn't matter
-        name: "Södertälje open".into(),
-        start_date,
-        end_date: start_date + Duration::days(1),
-    };
-    // insert tournament
-    let response = client
-        .post(&format!("{}/tournaments", &server_addr))
-        .json(&tournament)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-    let tournament_id = response.text().await.unwrap();
-
-    let player = Player {
-        id: 0,
-        name: "Göte svensson".into(),
-    };
-
-    // insert player 1
-    let response = client
-        .post(&format!("{}/players", &server_addr))
-        .json(&player)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-
-    let player = Player {
-        id: 1,
-        name: "Sture svensson".into(),
-    };
-
-    // insert player 2
-    let response = client
-        .post(&format!("{}/players", &server_addr))
-        .json(&player)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-
-    // insert match
-    let match_data = Match {
-        id: 0, // not important
-        player_one: 0,
-        player_two: 1,
-        tournament_id: tournament_id.parse::<i32>().unwrap(),
-        class: "p96".to_string(),
-        start_time: Local::now().naive_local() + Duration::hours(2),
-    };
-
-    let response = client
-        .post(&format!("{}/matches", &server_addr))
-        .json(&match_data)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-    let match_id = response.text().await.unwrap();
-
-    let player_registration_request = PlayerMatchRegistrationRequest {
-        player_id: 1,
-        registered_by: "Svante".to_string(),
-    };
-
-    // register player 2
-    let response = client
-        .post(&format!(
-            "{}/matches/{}/register/player",
-            &server_addr, match_id
-        ))
-        .json(&player_registration_request)
-        .send()
-        .await
-        .expect("Request failed");
-
-    assert!(response.status().is_success());
-
-    let actual = response.json::<PlayerMatchRegistration>().await.unwrap();
-
-    assert_eq!(1, actual.player_id);
-    assert_eq!(match_id.parse::<i64>().unwrap(), actual.match_id);
-    assert_eq!("Svante".to_string(), actual.registerd_by);
-}
-
-// TODO: add more match insertion tests

--- a/tests/match_tests.rs
+++ b/tests/match_tests.rs
@@ -1,0 +1,140 @@
+use chrono::{Duration, Local};
+use common::{spawn_server, TournamentTrackerClient};
+use reqwest::StatusCode;
+use tournament_tracker_backend::{
+    endpoints::PlayerMatchRegistrationRequest,
+    stores::{
+        match_store::Match, player_registration_store::PlayerMatchRegistration,
+        player_store::Player, tournament_store::Tournament,
+    },
+};
+
+mod common;
+
+async fn insert_tournament_and_players(client: &TournamentTrackerClient) -> (i32, i64, i64) {
+    let start_date = Local::today().naive_local();
+    let tournament = Tournament {
+        id: 0, // doesn't matter
+        name: "Södertälje open".into(),
+        start_date,
+        end_date: start_date + Duration::days(1),
+    };
+
+    // insert tournament
+    let response = client.insert_tournament(&tournament).await;
+    assert!(response.status().is_success());
+    let tournament_id = response.text().await.unwrap();
+
+    let player = Player {
+        id: 0,
+        name: "Göte svensson".into(),
+    };
+
+    // insert player 1
+    let response = client.insert_player(&player).await;
+    assert!(response.status().is_success());
+
+    let player = Player {
+        id: 1,
+        name: "Sture svensson".into(),
+    };
+
+    // insert player 2
+    let response = client.insert_player(&player).await;
+    assert!(response.status().is_success());
+
+    (tournament_id.parse::<i32>().unwrap(), 0, 1)
+}
+
+#[actix_rt::test]
+async fn should_fail_to_register_match_with_invalid_rooster() {
+    let client = spawn_server().await;
+
+    let (tournament_id, player_one, _) = insert_tournament_and_players(&client).await;
+
+    let match_data = Match {
+        id: 0, // not important
+        player_one,
+        player_two: player_one, // Can't play against yourself!
+        tournament_id,
+        class: "p96".to_string(),
+        start_time: Local::now().naive_local() + Duration::hours(2),
+    };
+
+    let response = client.insert_match(&match_data).await;
+    assert_eq!(response.status(), StatusCode::from_u16(400).unwrap());
+}
+
+#[actix_rt::test]
+async fn should_fail_to_register_match_with_invalid_start_date() {
+    let client = spawn_server().await;
+
+    let (tournament_id, player_one, player_two) = insert_tournament_and_players(&client).await;
+
+    let match_data = Match {
+        id: 0, // not important
+        player_one,
+        player_two,
+        tournament_id,
+        class: "p96".to_string(),
+        start_time: Local::now().naive_local() - Duration::hours(2),
+    };
+
+    let response = client.insert_match(&match_data).await;
+    assert_eq!(response.status(), StatusCode::from_u16(400).unwrap());
+}
+
+#[actix_rt::test]
+async fn should_fail_invalid_player_registration() {
+    let client = spawn_server().await;
+
+    let player_registration = PlayerMatchRegistrationRequest {
+        player_id: 0,
+        registered_by: "Svante".to_string(),
+    };
+
+    let response = client.register_player(2, &player_registration).await;
+    assert_eq!(response.status(), StatusCode::from_u16(500).unwrap());
+}
+
+#[actix_rt::test]
+async fn should_register_valid_player() {
+    let client = spawn_server().await;
+
+    let (tournament_id, player_one, player_two) = insert_tournament_and_players(&client).await;
+
+    // insert match
+    let match_data = Match {
+        id: 0, // not important
+        player_one,
+        player_two,
+        tournament_id,
+        class: "p96".to_string(),
+        start_time: Local::now().naive_local() + Duration::hours(2),
+    };
+
+    let response = client.insert_match(&match_data).await;
+    assert!(response.status().is_success());
+    let match_id = response.text().await.unwrap();
+
+    let player_registration = PlayerMatchRegistrationRequest {
+        player_id: 1,
+        registered_by: "Svante".to_string(),
+    };
+
+    // register player 2
+    let response = client
+        .register_player(match_id.parse::<i64>().unwrap(), &player_registration)
+        .await;
+    assert!(response.status().is_success());
+    let actual = response.json::<PlayerMatchRegistration>().await.unwrap();
+
+    assert_eq!(1, actual.player_id);
+    assert_eq!(match_id.parse::<i64>().unwrap(), actual.match_id);
+    assert_eq!("Svante".to_string(), actual.registerd_by);
+}
+
+#[actix_rt::test]
+async fn should_not_register_invalid_player() {
+    // TODO
+}

--- a/tests/match_tests.rs
+++ b/tests/match_tests.rs
@@ -118,7 +118,7 @@ async fn should_register_valid_player() {
     let match_id = response.text().await.unwrap();
 
     let player_registration = PlayerMatchRegistrationRequest {
-        player_id: 1,
+        player_id: player_one,
         registered_by: "Svante".to_string(),
     };
 
@@ -129,12 +129,60 @@ async fn should_register_valid_player() {
     assert!(response.status().is_success());
     let actual = response.json::<PlayerMatchRegistration>().await.unwrap();
 
-    assert_eq!(1, actual.player_id);
+    assert_eq!(player_one, actual.player_id);
     assert_eq!(match_id.parse::<i64>().unwrap(), actual.match_id);
     assert_eq!("Svante".to_string(), actual.registerd_by);
 }
 
 #[actix_rt::test]
 async fn should_not_register_invalid_player() {
-    // TODO
+    let client = spawn_server().await;
+
+    let (tournament_id, player_one, player_two) = insert_tournament_and_players(&client).await;
+
+    // insert match
+    let match_data = Match {
+        id: 0, // not important
+        player_one,
+        player_two,
+        tournament_id,
+        class: "p96".to_string(),
+        start_time: Local::now().naive_local() + Duration::hours(2),
+    };
+
+    let response = client.insert_match(&match_data).await;
+    assert!(response.status().is_success());
+    let match_id = response.text().await.unwrap();
+
+    // Try to register player not part of rooster
+    let player_registration = PlayerMatchRegistrationRequest {
+        player_id: 1337,
+        registered_by: "Svante".to_string(),
+    };
+    let response = client
+        .register_player(match_id.parse::<i64>().unwrap(), &player_registration)
+        .await;
+    assert!(response.status().is_client_error());
+
+
+    // Try to register player twice
+    let player_registration = PlayerMatchRegistrationRequest {
+        player_id: player_one,
+        registered_by: "Svante".to_string(),
+    };
+    let response = client
+        .register_player(match_id.parse::<i64>().unwrap(), &player_registration)
+        .await;
+    assert!(response.status().is_success());
+
+    // Second attempt should fail
+    let player_registration = PlayerMatchRegistrationRequest {
+        player_id: player_one,
+        registered_by: "Svante".to_string(),
+    };
+    let response = client
+        .register_player(match_id.parse::<i64>().unwrap(), &player_registration)
+        .await;
+    assert!(response.status().is_client_error())
+
 }

--- a/tests/match_tests.rs
+++ b/tests/match_tests.rs
@@ -164,7 +164,6 @@ async fn should_not_register_invalid_player() {
         .await;
     assert!(response.status().is_client_error());
 
-
     // Try to register player twice
     let player_registration = PlayerMatchRegistrationRequest {
         player_id: player_one,
@@ -184,5 +183,4 @@ async fn should_not_register_invalid_player() {
         .register_player(match_id.parse::<i64>().unwrap(), &player_registration)
         .await;
     assert!(response.status().is_client_error())
-
 }

--- a/tests/tournament_tests.rs
+++ b/tests/tournament_tests.rs
@@ -39,9 +39,7 @@ async fn invalid_date_test() {
 
     let response = client.insert_tournament(&tournament).await;
     assert!(!response.status().is_success());
-    assert_eq!(response.status(), StatusCode::from_u16(403).unwrap());
-    // id should not be part of the response
-    assert!(response.text().await.unwrap().is_empty());
+    assert_eq!(response.status(), StatusCode::from_u16(400).unwrap());
 }
 
 #[actix_rt::test]

--- a/tests/tournament_tests.rs
+++ b/tests/tournament_tests.rs
@@ -1,0 +1,79 @@
+use chrono::{Duration, Local};
+use common::spawn_server;
+use reqwest::StatusCode;
+use tournament_tracker_backend::stores::tournament_store::Tournament;
+
+mod common;
+
+#[actix_rt::test]
+async fn insert_tournament_test() {
+    let client = spawn_server().await;
+
+    let start_date = Local::today().naive_local();
+
+    let tournament = Tournament {
+        id: 0, // doesn't matter
+        name: "Södertälje open".into(),
+        start_date,
+        end_date: start_date + Duration::days(1),
+    };
+
+    let response = client.insert_tournament(&tournament).await;
+    assert!(response.status().is_success());
+    // id should be part of the response
+    assert!(!response.text().await.unwrap().is_empty());
+}
+
+#[actix_rt::test]
+async fn invalid_date_test() {
+    let client = spawn_server().await;
+
+    let start_date = Local::today().naive_local();
+
+    let tournament = Tournament {
+        id: 0, // doesn't matter
+        name: "Södertälje open".into(),
+        start_date,
+        end_date: start_date - Duration::days(1),
+    };
+
+    let response = client.insert_tournament(&tournament).await;
+    assert!(!response.status().is_success());
+    assert_eq!(response.status(), StatusCode::from_u16(403).unwrap());
+    // id should not be part of the response
+    assert!(response.text().await.unwrap().is_empty());
+}
+
+#[actix_rt::test]
+async fn get_tournament_test() {
+    let client = spawn_server().await;
+
+    let start_date = Local::today().naive_local();
+
+    let tournament = Tournament {
+        id: 0, // doesn't matter
+        name: "Södertälje open".into(),
+        start_date,
+        end_date: start_date + Duration::days(1),
+    };
+
+    let response = client.insert_tournament(&tournament).await;
+    assert!(response.status().is_success());
+
+    let response = client.get_tournaments().await;
+
+    assert!(response.status().is_success());
+
+    let tournament_list = response
+        .json::<Vec<Tournament>>()
+        .await
+        .expect("Response body");
+    assert_eq!(tournament_list.len(), 1);
+
+    let tournament = Tournament {
+        id: tournament_list[0].id,
+        ..tournament
+    };
+
+    assert_eq!(tournament_list[0], tournament);
+}


### PR DESCRIPTION
Adds a `TournamentTrackerClient` which cleans up some of the test code, it's also split between different files now. 

Matches now correctly check if the rooster is valid before allowing an insertion. 