### PR TITLE
Implement get tournament matches endpoint and start matches on final player registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "tokio 0.3.3",
  "tracing",
  "tracing-actix-web",
+ "tracing-appender",
  "tracing-bunyan-formatter",
  "tracing-futures",
  "tracing-log",
@@ -2498,6 +2499,17 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "uuid",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa52d56cc0d79ab604e8a022a1cebc4de33cf09dc9933c94353bea2e00d6e88"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ actix-web = "3"
 sqlx = { version = "0.4.1", default-features = false, features = ["runtime-actix-native-tls", "macros", "postgres", "offline", "chrono", "migrate"] }
 tracing = "0.1"
 tracing-futures = "0.2.4"
+tracing-appender = "0.1"
 tracing-subscriber = { version = "0.2.12", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.1"
 tracing-actix-web = "0.2"

--- a/migrations/20201101121702_tournament-tracker.sql
+++ b/migrations/20201101121702_tournament-tracker.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS matches (
 );
 
 CREATE TABLE IF NOT EXISTS court_queue (
-   place_in_queue  TIMESTAMP NOT NULL CHECK (place_in_queue > CURRENT_TIMESTAMP),
+   place_in_queue  TIMESTAMP NOT NULL CHECK (place_in_queue >= CURRENT_TIMESTAMP),
    match_id BIGINT NOT NULL,
    tournament_id INT NOT NULL,
    PRIMARY KEY (tournament_id, match_id),

--- a/migrations/20201101121702_tournament-tracker.sql
+++ b/migrations/20201101121702_tournament-tracker.sql
@@ -12,7 +12,7 @@
 CREATE TABLE IF NOT EXISTS tournaments (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL,
-  start_date DATE NOT NULL CHECK (start_date >= CURRENT_DATE),
+  start_date DATE NOT NULL,
   end_date DATE NOT NULL CHECK (start_date <= end_date)
 );
 
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS matches (
 );
 
 CREATE TABLE IF NOT EXISTS court_queue (
-   place_in_queue  TIMESTAMP NOT NULL CHECK (place_in_queue >= CURRENT_TIMESTAMP),
+   place_in_queue  TIMESTAMP NOT NULL,
    match_id BIGINT NOT NULL,
    tournament_id INT NOT NULL,
    PRIMARY KEY (tournament_id, match_id),

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,5 +1,55 @@
 {
   "db": "PostgreSQL",
+  "12327a22ce161ed382d641821b9a6618f74cc7181e10cd929b5a53f16ab7f8c0": {
+    "query": "SELECT * FROM matches WHERE tournament_id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "id",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "player_one",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 2,
+          "name": "player_two",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 3,
+          "name": "tournament_id",
+          "type_info": "Int4"
+        },
+        {
+          "ordinal": 4,
+          "name": "class",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 5,
+          "name": "start_time",
+          "type_info": "Timestamp"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      },
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
   "1526e8c7e058ca5b57bab50b11c42a2e3f22069df8d08f127fafc728a65c3dd6": {
     "query": "SELECT match_id FROM court_queue WHERE tournament_id = $1 ORDER BY place_in_queue ASC LIMIT 1",
     "describe": {
@@ -64,6 +114,38 @@
         false,
         false,
         false,
+        false,
+        false,
+        false
+      ]
+    }
+  },
+  "185c89fdf331faea9115e2a49fce3fc24a15c48f437dd931825d3e8b79a38553": {
+    "query": "SELECT * FROM match_result WHERE match_id = $1",
+    "describe": {
+      "columns": [
+        {
+          "ordinal": 0,
+          "name": "match_id",
+          "type_info": "Int8"
+        },
+        {
+          "ordinal": 1,
+          "name": "result",
+          "type_info": "Text"
+        },
+        {
+          "ordinal": 2,
+          "name": "winner",
+          "type_info": "Int8"
+        }
+      ],
+      "parameters": {
+        "Left": [
+          "Int8"
+        ]
+      },
+      "nullable": [
         false,
         false,
         false

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -48,11 +48,13 @@ pub async fn get_tournaments(db: Data<PgPool>) -> Result<impl Responder, ServerE
 
 #[tracing::instrument(name = "Get tournament matches", skip(db))]
 #[get("/tournaments/{id}/matches")]
-pub async fn get_tournament_matches(id: Path<i32>, db: Data<PgPool>) -> Result<impl Responder, ServerError> {
+pub async fn get_tournament_matches(
+    id: Path<i32>,
+    db: Data<PgPool>,
+) -> Result<impl Responder, ServerError> {
     let tournaments = db.get_tournaments().await?;
     Ok(HttpResponse::Ok().json(tournaments))
 }
-
 
 // Player endpoints
 #[tracing::instrument(name = "Insert player", skip(db))]

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -52,7 +52,8 @@ pub async fn get_tournament_matches(
     id: Path<i32>,
     db: Data<PgPool>,
 ) -> Result<impl Responder, ServerError> {
-    let tournaments = db.get_tournaments().await?;
+    let tournaments =
+        crate::match_operations::get_tournament_matches(*id, &*db.into_inner()).await?;
     Ok(HttpResponse::Ok().json(tournaments))
 }
 

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -46,6 +46,14 @@ pub async fn get_tournaments(db: Data<PgPool>) -> Result<impl Responder, ServerE
     Ok(HttpResponse::Ok().json(tournaments))
 }
 
+#[tracing::instrument(name = "Get tournament matches", skip(db))]
+#[get("/tournaments/{id}/matches")]
+pub async fn get_tournament_matches(id: Path<i32>, db: Data<PgPool>) -> Result<impl Responder, ServerError> {
+    let tournaments = db.get_tournaments().await?;
+    Ok(HttpResponse::Ok().json(tournaments))
+}
+
+
 // Player endpoints
 #[tracing::instrument(name = "Insert player", skip(db))]
 #[post("/players")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@ use tracing::{subscriber::set_global_default, Subscriber};
 use tracing_actix_web::TracingLogger;
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
-use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Registry};
+use tracing_subscriber::{
+    fmt::MakeWriter, prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Registry,
+};
 
 pub mod configuration;
 pub mod endpoints;
@@ -64,10 +66,11 @@ impl ResponseError for ServerError {
 pub fn get_trace_subscriber(
     name: String,
     fallback_filter: String,
+    writer: impl MakeWriter + Sync + Send + 'static,
 ) -> impl Subscriber + Send + Sync {
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(fallback_filter));
-    let formatting_layer = BunyanFormattingLayer::new(name, std::io::stdout);
+    let formatting_layer = BunyanFormattingLayer::new(name, writer);
 
     Registry::default()
         .with(env_filter)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub fn run(listener: TcpListener, db_pool: PgPool) -> io::Result<Server> {
             .service(get_player)
             .service(register_player)
             .service(insert_match)
+            .service(get_tournament_matches)
     })
     .listen(listener)?
     .run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use tournament_tracker_backend::{
 
 #[actix_web::main]
 async fn main() -> io::Result<()> {
-    let subscriber = get_trace_subscriber("tournament-tracker".into(), "info".into());
+    let (non_blocking, _guard) = tracing_appender::non_blocking(std::io::stdout());
+    let subscriber = get_trace_subscriber("tournament-tracker".into(), "info".into(), non_blocking);
     init_subscriber(subscriber);
 
     let config = get_configuration().expect("Failed to read configuration");

--- a/src/match_operations.rs
+++ b/src/match_operations.rs
@@ -108,15 +108,16 @@ pub async fn get_tournament_matches<S: MatchStore + PlayerStore>(
     let scheduled = Vec::new();
 
     for match_data in query_result.iter() {
-         match get_match_player_info(storage, match_data).await {
-             Ok(player_match_info ) => {
-                
-             }
-             Err(err) => {
-                 warn!("Player info not found for match: {}", err);
-             }
-         }
+        match get_match_player_info(storage, match_data).await {
+            Ok(player_match_info) => {
+                // TODO ADD TESTS
+            }
+            Err(err) => {
+                warn!("Player info not found for match: {}", err);
+            }
+        }
     }
+    todo!();
 }
 
 #[tracing::instrument(name = "Start match", skip(storage))]

--- a/src/stores/court_store.rs
+++ b/src/stores/court_store.rs
@@ -71,7 +71,7 @@ impl CourtStore for PgPool {
 
     #[tracing::instrument(name = "Fetching match court", skip(self))]
     async fn get_match_court(&self, tournament_id: i32, match_id: i64) -> Option<String> {
-         sqlx::query!("SELECT court_name FROM tournament_court_allocation WHERE tournament_id = $1 AND match_id = $2", 
+        sqlx::query!("SELECT court_name FROM tournament_court_allocation WHERE tournament_id = $1 AND match_id = $2", 
             tournament_id,
             match_id
         )
@@ -79,7 +79,7 @@ impl CourtStore for PgPool {
         .await
         .map_err(|err| {
             error!("Failed fetch match court: {}", err);
-            err 
+            err
         })
         .ok()
         .flatten()

--- a/src/stores/court_store.rs
+++ b/src/stores/court_store.rs
@@ -26,17 +26,14 @@ pub trait CourtStore {
         tournament_court_allocation: TournamentCourtAllocation,
     ) -> Result<(), sqlx::Error>;
 
-    async fn get_match_court(
-        &self,
-        tournament_id: i32,
-        match_id: i64,
-    ) -> Result<Option<String>, sqlx::Error>;
-    // TODO: make this return result instead
+    async fn get_match_court(&self, tournament_id: i32, match_id: i64) -> Option<String>;
+
     async fn try_assign_free_court(
         &self,
         tournament_id: i32,
         match_id: i64,
-    ) -> Result<Option<String>, sqlx::Error>;
+    ) -> Result<String, sqlx::Error>;
+
     async fn append_court_queue(
         &self,
         tournament_id: i32,
@@ -73,12 +70,8 @@ impl CourtStore for PgPool {
     }
 
     #[tracing::instrument(name = "Fetching match court", skip(self))]
-    async fn get_match_court(
-        &self,
-        tournament_id: i32,
-        match_id: i64,
-    ) -> Result<Option<String>, sqlx::Error> {
-        let row = sqlx::query!("SELECT court_name FROM tournament_court_allocation WHERE tournament_id = $1 AND match_id = $2", 
+    async fn get_match_court(&self, tournament_id: i32, match_id: i64) -> Option<String> {
+         sqlx::query!("SELECT court_name FROM tournament_court_allocation WHERE tournament_id = $1 AND match_id = $2", 
             tournament_id,
             match_id
         )
@@ -86,9 +79,11 @@ impl CourtStore for PgPool {
         .await
         .map_err(|err| {
             error!("Failed fetch match court: {}", err);
-            err
-        })?;
-        Ok(row.map(|row| row.court_name))
+            err 
+        })
+        .ok()
+        .flatten()
+        .map(|test| test.court_name)
     }
 
     #[tracing::instrument(name = "Trying to assign free court to match", skip(self))]
@@ -96,7 +91,7 @@ impl CourtStore for PgPool {
         &self,
         tournament_id: i32,
         match_id: i64,
-    ) -> Result<Option<String>, sqlx::Error> {
+    ) -> Result<String, sqlx::Error> {
         let row = sqlx::query!("UPDATE tournament_court_allocation SET match_id = $1 WHERE tournament_id = $2 AND match_id = NULL RETURNING court_name",
             match_id,
             tournament_id
@@ -107,7 +102,11 @@ impl CourtStore for PgPool {
             error!("Failed assign free court: {}", err);
             err
         })?;
-        Ok(row.map(|row| row.court_name))
+        if let Some(free_court) = row {
+            Ok(free_court.court_name)
+        } else {
+            Err(sqlx::Error::RowNotFound)
+        }
     }
 
     #[tracing::instrument(name = "Appending match to court queue", skip(self))]

--- a/src/stores/match_store.rs
+++ b/src/stores/match_store.rs
@@ -50,13 +50,17 @@ impl MatchStore for PgPool {
 
     #[tracing::instrument(name = "Fetching tournament matches", skip(self))]
     async fn get_tournament_matches(&self, tournament_id: i32) -> Result<Vec<Match>, sqlx::Error> {
-        let matches = sqlx::query_as!(Match, "SELECT * FROM matches WHERE tournament_id = $1", tournament_id)
-            .fetch_all(self)
-            .await
-            .map_err(|err| {
-                error!("Failed to fetch matches for tournament: {}", err);
-                err
-            })?;
+        let matches = sqlx::query_as!(
+            Match,
+            "SELECT * FROM matches WHERE tournament_id = $1",
+            tournament_id
+        )
+        .fetch_all(self)
+        .await
+        .map_err(|err| {
+            error!("Failed to fetch matches for tournament: {}", err);
+            err
+        })?;
         Ok(matches)
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -92,7 +92,7 @@ impl TournamentTrackerClient {
 
 lazy_static::lazy_static! {
     static ref TRACING: () = {
-        let subscriber = get_trace_subscriber("Test server".into(), "debug".into());
+        let subscriber = get_trace_subscriber("Test server".into(), "debug".into(), || std::io::stdout());
         init_subscriber(subscriber);
     };
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -36,6 +36,17 @@ impl TournamentTrackerClient {
             .expect("Request failed")
     }
 
+    pub async fn get_tournaments_matches(&self, tournament_id: i32) -> Response {
+        self.client
+            .get(&format!(
+                "{}/tournaments/{}/matches",
+                &self.server_addr, tournament_id,
+            ))
+            .send()
+            .await
+            .expect("Request failed")
+    }
+
     pub async fn insert_player(&self, player: &Player) -> Response {
         self.client
             .post(&format!("{}/players", &self.server_addr))

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::net::TcpListener;
 
 use reqwest::{Client, Response};

--- a/tests/match_tests.rs
+++ b/tests/match_tests.rs
@@ -98,7 +98,7 @@ async fn should_fail_to_register_to_missing_match() {
 }
 
 #[actix_rt::test]
-async fn should_register_valid_player() {
+async fn should_register_valid_player_and_start_match() {
     let client = spawn_server().await;
 
     let (tournament_id, player_one, player_two) = insert_tournament_and_players(&client).await;
@@ -132,6 +132,9 @@ async fn should_register_valid_player() {
     assert_eq!(player_one, actual.player_id);
     assert_eq!(match_id.parse::<i64>().unwrap(), actual.match_id);
     assert_eq!("Svante".to_string(), actual.registerd_by);
+
+    // ensure the match has started, the match will be #1 in the court queue
+    client
 }
 
 #[actix_rt::test]

--- a/tests/match_tests.rs
+++ b/tests/match_tests.rs
@@ -141,7 +141,7 @@ async fn should_register_valid_player_and_start_match() {
     // ensure the match has started, the match will be #1 in the court queue
     let response = client.get_tournaments_matches(tournament_id).await;
     assert!(response.status().is_success());
-    let match_list = dbg!(response.json::<TournamentMatchList>().await.unwrap());
+    let match_list = response.json::<TournamentMatchList>().await.unwrap();
     let scheduled_match = &match_list.scheduled[0];
     assert_eq!(scheduled_match.id, match_id);
     // first in the queue


### PR DESCRIPTION
More tests to be added in follow up prs. When both players have been registered to a match it will automatically be started or added to the court queue depending on if there are free courts. Get tournament matches endpoint allows returns `MatchInfo` jsons split into `scheduled`, `finished` and `playing`