### PR TITLE
Set server private key via ENV variable or config files

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -39,7 +39,8 @@ jobs:
       #- name: Check sqlx-data.json metadata file
       #  run: cargo sqlx prepare --check -- --bin app
       - uses: actions-rs/cargo@v1
-        env: 
+        env:
+          APP_APPLICATION__PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }} 
           SQLX_OFFLINE: true
         with:
           command: test
@@ -119,6 +120,7 @@ jobs:
           override: true
       - name: Run cargo-tarpaulin
         env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }} 
           SQLX_OFFLINE: true
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -120,7 +120,7 @@ jobs:
           override: true
       - name: Run cargo-tarpaulin
         env:
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }} 
+          APP_APPLICATION__PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           SQLX_OFFLINE: true
         uses: actions-rs/tarpaulin@v0.1
         with:

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,9 +1,10 @@
+use crate::configuration::Settings;
 use crate::{stores::user_store::UserStore, ServerError};
 use actix_web::{dev::ServiceRequest, Error};
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use chrono::Local;
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
-use once_cell::sync::Lazy;
+use once_cell::sync::{Lazy, OnceCell};
 use regex::Regex;
 use serde::Deserialize;
 use serde::Serialize;
@@ -11,14 +12,28 @@ use sqlx::PgPool;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-const TEMP_SECRET: &[u8] = &[0; 512];
 const THREE_DAYS_SECONDS: usize = 60 * 60 * 24 * 3;
+const PATTERN: &str = include_str!("../email_regex.txt");
+static DECODING_KEY: OnceCell<DecodingKey> = OnceCell::new();
+static ENCODING_KEY: OnceCell<EncodingKey> = OnceCell::new();
+static EMAIL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(PATTERN).expect("Regex is invalid"));
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
     exp: usize,
     iat: usize,
     sub: String,
+}
+
+pub fn set_keys(config: &Settings) {
+    let key = &config.application.private_key;
+    assert!(48 <= key.len(), "Private key is too short");
+    DECODING_KEY
+        .set(DecodingKey::from_base64_secret(key).expect("Key must be base64 encoded"))
+        .expect("Failed to set decoding key");
+    ENCODING_KEY
+        .set(EncodingKey::from_base64_secret(key).expect("Key must be base64 encoded"))
+        .expect("Failed to set encoding key");
 }
 
 // Authenticate the request given an auth token
@@ -33,13 +48,15 @@ pub async fn authenticate_request(
         ..Validation::default()
     };
 
-    let decoded_token =
-        decode::<Claims>(token, &DecodingKey::from_secret(TEMP_SECRET), &validation).map_err(
-            |err| {
-                warn!("Token decoding error: {}", err);
-                ServerError::InvalidToken
-            },
-        )?;
+    let decoded_token = decode::<Claims>(
+        token,
+        &DECODING_KEY.get().expect("Decoding key hasn't been set"),
+        &validation,
+    )
+    .map_err(|err| {
+        warn!("Token decoding error: {}", err);
+        ServerError::InvalidToken
+    })?;
 
     let uuid = Uuid::parse_str(&decoded_token.claims.sub).map_err(|err| {
         error!(
@@ -55,9 +72,6 @@ pub async fn authenticate_request(
         Err(ServerError::InvalidToken.into())
     }
 }
-
-const PATTERN: &str = include_str!("../email_regex.txt");
-static EMAIL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(PATTERN).expect("Regex is invalid"));
 
 // Authenticate an user and return a JWT token if the credentials are valid
 pub async fn login_user(
@@ -90,7 +104,7 @@ pub async fn login_user(
         let token = encode(
             &Header::default(),
             &claims,
-            &EncodingKey::from_secret(TEMP_SECRET),
+            &ENCODING_KEY.get().expect("Encoding key hasn't been set"),
         )
         .map_err(|err| {
             error!("Failed to encode JWT token: {}", err);

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -2,15 +2,18 @@ use config::{Config, Environment, File};
 use serde::Deserialize;
 use serde_aux::field_attributes::deserialize_number_from_string;
 use sqlx::postgres::{PgConnectOptions, PgSslMode};
+use tracing::error;
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 pub struct ApplicationSettings {
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub port: u16,
     pub host: String,
+    // DO NOT PRINT THIS IN LOGS!!
+    pub private_key: String,
 }
-
-#[derive(Debug, Deserialize)]
+// DON'T DERIVE DEBUG TO AVOID ACCIDENTAL LOGGING!
+#[derive(Deserialize)]
 pub struct Settings {
     pub database: DatabaseSettings,
     pub application: ApplicationSettings,
@@ -64,11 +67,19 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     let env = std::env::var("ENVIROMENT").unwrap_or_else(|_| "local".into());
 
     // Layer on the environment-specific values.
-    settings.merge(config::File::from(config_dir.join(env)).required(true))?;
+    settings.merge(config::File::from(config_dir.join(env.clone())).required(true))?;
 
     // Allows ENV variables to override the yaml settings
     // ex APP_APPLICATION__PORT=1337
     settings.merge(Environment::with_prefix("app").separator("__"))?;
 
-    settings.try_into()
+    let settings: Settings = settings.try_into()?;
+    if settings.application.private_key.is_empty() {
+        error!("Private key is not properly set!");
+        Err(config::ConfigError::Message(
+            "Private key isn't set".to_string(),
+        ))
+    } else {
+        Ok(settings)
+    }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -67,7 +67,7 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     let env = std::env::var("ENVIROMENT").unwrap_or_else(|_| "local".into());
 
     // Layer on the environment-specific values.
-    settings.merge(config::File::from(config_dir.join(env.clone())).required(true))?;
+    settings.merge(config::File::from(config_dir.join(env)).required(true))?;
 
     // Allows ENV variables to override the yaml settings
     // ex APP_APPLICATION__PORT=1337

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
 use tracing_subscriber::{fmt::MakeWriter, prelude::*, EnvFilter, Registry};
 
-mod authentication;
+pub mod authentication;
 pub mod configuration;
 pub mod endpoints;
 pub mod match_operations;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use sqlx::postgres::PgPoolOptions;
 use std::{io, net::TcpListener};
+use tournament_tracker_backend::authentication::set_keys;
 use tournament_tracker_backend::{
     configuration::get_configuration, get_trace_subscriber, init_subscriber, run,
 };
@@ -11,6 +12,7 @@ async fn main() -> io::Result<()> {
     init_subscriber(subscriber);
 
     let config = get_configuration().expect("Failed to read configuration");
+    set_keys(&config);
 
     let connection_pool = PgPoolOptions::new()
         .connect_timeout(std::time::Duration::from_secs(5))


### PR DESCRIPTION
This means that when testing locally you have to set the `APP_APPLICATION__PRIVATE_KEY` env variable to a base64 encoded key of at least length 48. One can use `gpg --gen-random 1 48 | base64`  to generate it. However it's also possible to set the `private_key` field in the `local.yaml` config but I didn't do it here because I want to test out github secrets.

Fixes: #23 